### PR TITLE
Version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Attributable
 A proposal for a standard approach to manage attributes on chain for NFTs
 
+### ALERT This is a work in progress and breaking changes can be introduced at any time.
+
 ## Premise
 
 In 2021, I proposed a standard for on-chain attributes for NFT at https://github.com/ndujaLabs/erc721playable  
@@ -275,6 +277,11 @@ import "@ndujalabs/attributable/contracts/IAttributablePlayer.sol";
 Feel free to make a PR to add your contracts.
 
 ## History
+
+**0.0.3**
+- Moved from uint8 to uint256 in functions
+- Rename `authorizePlayer` to `initializePlayerFor` in `IAttributable`
+- Interface ID has changed, breaking the compatibility with previous implementations
 
 **0.0.2**
 - Renamed IPlayer to IAttributablePlayer to avoid a too generic name.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,8 @@ mapping(uint256 => mapping(address => uint256)) internal _tokenAttributes;
 The problem is that a single integer may not be enough. A better solution is to have an "array" of big integers. My preferred variable would be
 
 ```solidity
-mapping(uint256 => mapping(address => mapping(uint8 => uint256))) internal _tokenAttributes;
+mapping(uint256 => mapping(address => mapping(uint256 => uint256))) internal _tokenAttributes;
 ```
-
-This way, you can have a maximum of 256 values which should cover the 99.9% of the use cases.
 
 Regardless, the optimal data format is not central, and the choice of what to use is left to the implementation of the NFT. What is more important here is to define how the NFT (or any other asset with an ID) interfaces with the player.
 
@@ -60,7 +58,7 @@ pragma solidity ^0.8.4;
 /**
    @title IAttributable Cross-player On-chain Attributes
     Version: 0.0.1
-   ERC165 interfaceId is 0x8de3c46d
+   ERC165 interfaceId is 0xc79cd306
    */
 interface IAttributable {
   /**
@@ -87,7 +85,7 @@ interface IAttributable {
   function attributesOf(
     uint256 _id,
     address _player,
-    uint8 _index
+    uint256 _index
   ) external view returns (uint256);
 
   /**
@@ -107,7 +105,7 @@ interface IAttributable {
      @param _id The id of the token for whom to authorize the player
      @param _player The address of the player contract
    */
-  function authorizePlayer(uint256 _id, address _player) external;
+  function initializeAttributesFor(uint256 _id, address _player) external;
 
   /**
      @notice Sets the attributes of a token after the initialization
@@ -124,7 +122,7 @@ interface IAttributable {
    */
   function updateAttributes(
     uint256 _id,
-    uint8 _index,
+    uint256 _index,
     uint256 _attributes
   ) external;
 }

--- a/contracts/IAttributable.sol
+++ b/contracts/IAttributable.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.4;
 /**
    @title IAttributable Cross-player On-chain Attributes
     Version: 0.0.1
-   ERC165 interfaceId is 0x8de3c46d
+   ERC165 interfaceId is 0xc79cd306
    */
 interface IAttributable {
   /**
@@ -34,12 +34,12 @@ interface IAttributable {
   function attributesOf(
     uint256 _id,
     address _player,
-    uint8 _index
+    uint256 _index
   ) external view returns (uint256);
 
   /**
-     @notice Authorize a player initializing the attributes of a token to 1
-     @dev It must be called by the nft's owner to approve the player.
+     @notice Authorize a player initializing the attributes of a token to a non zero value
+     @dev It must be called by the owner of the nft
 
        To avoid that nft owners give themselves arbitrary values, they must not
        be able to set up the values, but only to create the array that later
@@ -54,7 +54,7 @@ interface IAttributable {
      @param _id The id of the token for whom to authorize the player
      @param _player The address of the player contract
    */
-  function authorizePlayer(uint256 _id, address _player) external;
+  function initializeAttributesFor(uint256 _id, address _player) external;
 
   /**
      @notice Sets the attributes of a token after the initialization
@@ -71,7 +71,7 @@ interface IAttributable {
    */
   function updateAttributes(
     uint256 _id,
-    uint8 _index,
+    uint256 _index,
     uint256 _attributes
   ) external;
 }

--- a/contracts/examples/MyPlayer.sol
+++ b/contracts/examples/MyPlayer.sol
@@ -18,6 +18,7 @@ contract MyPlayer is IAttributablePlayer, Ownable, ERC165 {
     address winner;
   }
 
+  // convenient function, for testing only
   function getInterfaceIds() public view returns (bytes4, bytes4) {
     return (type(IAttributable).interfaceId, type(IAttributablePlayer).interfaceId);
   }
@@ -60,4 +61,5 @@ contract MyPlayer is IAttributablePlayer, Ownable, ERC165 {
       return "";
     }
   }
+
 }

--- a/contracts/examples/MyToken.sol
+++ b/contracts/examples/MyToken.sol
@@ -10,7 +10,7 @@ contract MyToken is ERC721, Ownable, IAttributable {
   constructor() ERC721("MyToken", "MTK") {}
 
   uint256 internal _nextTokenId = 1;
-  mapping(uint256 => mapping(address => mapping(uint8 => uint256))) internal _tokenAttributes;
+  mapping(uint256 => mapping(address => mapping(uint256 => uint256))) internal _tokenAttributes;
 
   function supportsInterface(bytes4 interfaceId) public view override(ERC721) returns (bool) {
     return interfaceId == type(IAttributable).interfaceId || super.supportsInterface(interfaceId);
@@ -19,12 +19,12 @@ contract MyToken is ERC721, Ownable, IAttributable {
   function attributesOf(
     uint256 _id,
     address _player,
-    uint8 _index
+    uint256 _index
   ) external view override returns (uint256) {
     return _tokenAttributes[_id][_player][_index];
   }
 
-  function authorizePlayer(uint256 _id, address _player) external override {
+  function initializeAttributesFor(uint256 _id, address _player) external override {
     require(ownerOf(_id) == _msgSender(), "Not the owner");
     require(_tokenAttributes[_id][_player][0] == 0, "Player already authorized");
     // this must be initialized to a non zero value.
@@ -35,7 +35,7 @@ contract MyToken is ERC721, Ownable, IAttributable {
 
   function updateAttributes(
     uint256 _id,
-    uint8 _index,
+    uint256 _index,
     uint256 _attributes
   ) external override {
     require(_tokenAttributes[_id][_msgSender()][0] != 0, "Player not authorized");
@@ -50,4 +50,5 @@ contract MyToken is ERC721, Ownable, IAttributable {
   function mint(address to) external onlyOwner {
     _safeMint(to, _nextTokenId++);
   }
+
 }

--- a/contracts/examples/MyTokenUpgradeable.sol
+++ b/contracts/examples/MyTokenUpgradeable.sol
@@ -15,7 +15,7 @@ contract MyTokenUpgradeable is IAttributable, Initializable, ERC721Upgradeable, 
   }
 
   uint256 internal _nextTokenId;
-  mapping(uint256 => mapping(address => mapping(uint8 => uint256))) internal _tokenAttributes;
+  mapping(uint256 => mapping(address => mapping(uint256 => uint256))) internal _tokenAttributes;
 
   function initialize() public initializer {
     __ERC721_init("MyToken", "MTK");
@@ -33,12 +33,12 @@ contract MyTokenUpgradeable is IAttributable, Initializable, ERC721Upgradeable, 
   function attributesOf(
     uint256 _id,
     address _player,
-    uint8 _index
+    uint256 _index
   ) external view override returns (uint256) {
     return _tokenAttributes[_id][_player][_index];
   }
 
-  function authorizePlayer(uint256 _id, address _player) external override {
+  function initializeAttributesFor(uint256 _id, address _player) external override {
     require(ownerOf(_id) == _msgSender(), "Not the owner");
     require(_tokenAttributes[_id][_player][0] == 0, "Player already authorized");
     _tokenAttributes[_id][_player][0] = 1;
@@ -47,7 +47,7 @@ contract MyTokenUpgradeable is IAttributable, Initializable, ERC721Upgradeable, 
 
   function updateAttributes(
     uint256 _id,
-    uint8 _index,
+    uint256 _index,
     uint256 _attributes
   ) external override {
     require(_tokenAttributes[_id][_msgSender()][0] != 0, "Player not authorized");

--- a/test/Attributable.test.js
+++ b/test/Attributable.test.js
@@ -26,7 +26,9 @@ describe("Attributable", function () {
 
   it("should verify the flow", async function () {
 
-    expect(await myToken.supportsInterface("0x8de3c46d")).equal(true)
+    // console.log(await myPlayer.getInterfaceIds())
+
+    expect(await myToken.supportsInterface("0xc79cd306")).equal(true)
     expect(await myPlayer.supportsInterface("0x72261e7d")).equal(true)
 
     await myToken.connect(owner).mint(holder.address);
@@ -48,7 +50,7 @@ describe("Attributable", function () {
         tokenData
     )).revertedWith("Player not authorized")
 
-    expect(await myToken.connect(holder).authorizePlayer(tokenId, myPlayer.address))
+    expect(await myToken.connect(holder).initializeAttributesFor(tokenId, myPlayer.address))
         .to.emit(myToken, 'AttributesInitializedFor')
         .withArgs(tokenId, myPlayer.address);
 


### PR DESCRIPTION
After discussion with members of the community, I changed the signature of the function, expecting a uint256 where previously it was expecting a uint8, since the gas used in storage it would be the same, and actually the computation can cost more. 

This changes the interfaceId, breaking compatibility with previous version.