### PR TITLE
Modifying signature of the event AttributesUpdated to include the player

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ interface IERC721Attributable {
       the marketplace can query the player to get the attributes of the NFT in within
       the game.
      @notice This is V2 of the interface. It is compatible with V1, but it does not emit the
-      AttributesUpdated event anymore, replacing it with AttributesUpdatedBy. It implies
+      AttributesUpdated event anymore, replacing it with AttributesUpdated. It implies
       that any contract using this interface must be updated to use the new event. 
    */
   event AttributesInitializedFor(uint256 indexed _id, address indexed _player);
@@ -67,7 +67,7 @@ interface IERC721Attributable {
   /**
    @dev Emitted when the attributes for an id are updated in relation to a specific player.
    */
-  event AttributesUpdatedBy(uint256 indexed _id, address indexed _player);
+  event AttributesUpdated(uint256 indexed _id, address indexed _player);
 
   /**
      @dev It returns the on-chain attributes of a specific id

--- a/README.md
+++ b/README.md
@@ -49,31 +49,25 @@ Regardless, the optimal data format is not central, and the choice of what to us
 ### IERC721Attributable - the NFT should extend it
 
 ```solidity
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
-
-/**
-   @title IERC721Attributable Cross-player On-chain Attributes
-    Version: 0.0.4
-   ERC165 interfaceId is 0xc79cd306
-   */
 interface IERC721Attributable {
   /**
      @dev Emitted when the attributes for an id and a player is set.
-          The function must be called by the owner of the asset to authorize a player to set
-          attributes on it. The rules for that are left to the asset.
-
-          This event is important because allows a marketplace to know that there are
-          dynamic attributes set on the NFT by a specific contract (the player) so that
-          the marketplace can query the player to get the attributes of the NFT in within
-          the game.
+      The function must be called by the owner of the asset to authorize a player to set
+      attributes on it. The rules for that are left to the asset.
+      This event is important because allows a marketplace to know that there are
+      dynamic attributes set on the NFT by a specific contract (the player) so that
+      the marketplace can query the player to get the attributes of the NFT in within
+      the game.
+     @notice This is V2 of the interface. It is compatible with V1, but it does not emit the
+      AttributesUpdated event anymore, replacing it with AttributesUpdatedBy. It implies
+      that any contract using this interface must be updated to use the new event. 
    */
   event AttributesInitializedFor(uint256 indexed _id, address indexed _player);
 
   /**
-   @dev Emitted when the attributes for an id are updated.
+   @dev Emitted when the attributes for an id are updated in relation to a specific player.
    */
-  event AttributesUpdated(uint256 indexed _id);
+  event AttributesUpdatedBy(uint256 indexed _id, address indexed _player);
 
   /**
      @dev It returns the on-chain attributes of a specific id
@@ -117,7 +111,7 @@ interface IERC721Attributable {
        The owner of the NFT must not be able to update the attributes.
 
        It must revert if the asset is not initialized for that player (the msg.sender).
-       
+
        The function must emit the AttributesUpdated event
 
      @param _id The id of the token for whom to change the attributes
@@ -130,8 +124,6 @@ interface IERC721Attributable {
     uint256 _attributes
   ) external;
 }
-
-
 ```
 
 ### IERC721AttributablePlayer - the player should extend it

--- a/contracts/IERC721Attributable.sol
+++ b/contracts/IERC721Attributable.sol
@@ -6,26 +6,28 @@ pragma solidity ^0.8.4;
 
 /**
    @title IERC721Attributable Cross-player On-chain Attributes
-    Version: 0.0.4
+    Version: 0.2.0
    ERC165 interfaceId is 0xc79cd306
    */
 interface IERC721Attributable {
   /**
      @dev Emitted when the attributes for an id and a player is set.
-          The function must be called by the owner of the asset to authorize a player to set
-          attributes on it. The rules for that are left to the asset.
-
-          This event is important because allows a marketplace to know that there are
-          dynamic attributes set on the NFT by a specific contract (the player) so that
-          the marketplace can query the player to get the attributes of the NFT in within
-          the game.
+      The function must be called by the owner of the asset to authorize a player to set
+      attributes on it. The rules for that are left to the asset.
+      This event is important because allows a marketplace to know that there are
+      dynamic attributes set on the NFT by a specific contract (the player) so that
+      the marketplace can query the player to get the attributes of the NFT in within
+      the game.
+     @notice This is V2 of the interface. It is compatible with V1, but it does not emit the
+      AttributesUpdated event anymore, replacing it with AttributesUpdatedBy. It implies
+      that any contract using this interface must be updated to use the new event.
    */
   event AttributesInitializedFor(uint256 indexed _id, address indexed _player);
 
   /**
-   @dev Emitted when the attributes for an id are updated.
+   @dev Emitted when the attributes for an id are updated in relation to a specific player.
    */
-  event AttributesUpdated(uint256 indexed _id);
+  event AttributesUpdatedBy(uint256 indexed _id, address indexed _player);
 
   /**
      @dev It returns the on-chain attributes of a specific id

--- a/contracts/IERC721Attributable.sol
+++ b/contracts/IERC721Attributable.sol
@@ -19,7 +19,7 @@ interface IERC721Attributable {
       the marketplace can query the player to get the attributes of the NFT in within
       the game.
      @notice This is V2 of the interface. It is compatible with V1, but it does not emit the
-      AttributesUpdated event anymore, replacing it with AttributesUpdatedBy. It implies
+      AttributesUpdated event anymore, replacing it with AttributesUpdated. It implies
       that any contract using this interface must be updated to use the new event.
    */
   event AttributesInitializedFor(uint256 indexed _id, address indexed _player);
@@ -27,7 +27,7 @@ interface IERC721Attributable {
   /**
    @dev Emitted when the attributes for an id are updated in relation to a specific player.
    */
-  event AttributesUpdatedBy(uint256 indexed _id, address indexed _player);
+  event AttributesUpdated(uint256 indexed _id, address indexed _player);
 
   /**
      @dev It returns the on-chain attributes of a specific id

--- a/contracts/examples/MyToken.sol
+++ b/contracts/examples/MyToken.sol
@@ -45,7 +45,7 @@ contract MyToken is ERC721, Ownable, IERC721Attributable {
     // Alternatively, the it could use a separate boolean to track the authorized players
     // but that would take extra gas without a clear advantage.
     _tokenAttributes[_id][_msgSender()][_index] = _attributes;
-    emit AttributesUpdated(_id);
+    emit AttributesUpdatedBy(_id, _msgSender());
   }
 
   function mint(address to) external onlyOwner {

--- a/contracts/examples/MyToken.sol
+++ b/contracts/examples/MyToken.sol
@@ -45,7 +45,7 @@ contract MyToken is ERC721, Ownable, IERC721Attributable {
     // Alternatively, the it could use a separate boolean to track the authorized players
     // but that would take extra gas without a clear advantage.
     _tokenAttributes[_id][_msgSender()][_index] = _attributes;
-    emit AttributesUpdatedBy(_id, _msgSender());
+    emit AttributesUpdated(_id, _msgSender());
   }
 
   function mint(address to) external onlyOwner {

--- a/contracts/examples/MyTokenUpgradeable.sol
+++ b/contracts/examples/MyTokenUpgradeable.sol
@@ -52,7 +52,7 @@ contract MyTokenUpgradeable is IERC721Attributable, Initializable, ERC721Upgrade
   ) external override {
     require(_tokenAttributes[_id][_msgSender()][0] != 0, "Player not authorized");
     _tokenAttributes[_id][_msgSender()][_index] = _attributes;
-    emit AttributesUpdatedBy(_id, _msgSender());
+    emit AttributesUpdated(_id, _msgSender());
   }
 
   function mint(address to) external onlyOwner {

--- a/contracts/examples/MyTokenUpgradeable.sol
+++ b/contracts/examples/MyTokenUpgradeable.sol
@@ -17,7 +17,7 @@ contract MyTokenUpgradeable is IERC721Attributable, Initializable, ERC721Upgrade
   uint256 internal _nextTokenId;
   mapping(uint256 => mapping(address => mapping(uint256 => uint256))) internal _tokenAttributes;
 
-  function initialize() public initializer {
+  function initialize() public onlyInitializing {
     __ERC721_init("MyToken", "MTK");
     __Ownable_init();
     __UUPSUpgradeable_init();
@@ -52,7 +52,7 @@ contract MyTokenUpgradeable is IERC721Attributable, Initializable, ERC721Upgrade
   ) external override {
     require(_tokenAttributes[_id][_msgSender()][0] != 0, "Player not authorized");
     _tokenAttributes[_id][_msgSender()][_index] = _attributes;
-    emit AttributesUpdated(_id);
+    emit AttributesUpdatedBy(_id, _msgSender());
   }
 
   function mint(address to) external onlyOwner {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndujalabs/erc721attributable",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A proposal for on-chain attributes for NFT and other assets",
   "publishConfig": {
     "access": "public"

--- a/test/Attributable.test.js
+++ b/test/Attributable.test.js
@@ -60,7 +60,7 @@ describe("ERC721Attributable", function () {
         myToken.address,
         tokenId,
         tokenData
-    )).emit(myToken, "AttributesUpdatedBy").withArgs(tokenId, myPlayer.address);
+    )).emit(myToken, "AttributesUpdated").withArgs(tokenId, myPlayer.address);
 
     attributes = await myToken.attributesOf(tokenId, myPlayer.address, 0);
     expect(attributes).to.equal("106752917089902064595775439782685550631690247383499200986087937");

--- a/test/Attributable.test.js
+++ b/test/Attributable.test.js
@@ -60,7 +60,7 @@ describe("ERC721Attributable", function () {
         myToken.address,
         tokenId,
         tokenData
-    )).emit(myToken, "AttributesUpdated").withArgs(tokenId)
+    )).emit(myToken, "AttributesUpdatedBy").withArgs(tokenId, myPlayer.address);
 
     attributes = await myToken.attributesOf(tokenId, myPlayer.address, 0);
     expect(attributes).to.equal("106752917089902064595775439782685550631690247383499200986087937");


### PR DESCRIPTION
In the previous version the event was communicating that the attributes of a specific tokenId were updated but not giving info about which player updated them, it was almost useless. 